### PR TITLE
Added support for localization

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,8 +10,6 @@
 </template>
 
 <script>
-import db from './database'
-
 import Sidebar from './components/Sidebar.vue'
 import Navigation from './components/Navigation.vue'
 import Icons from './components/Icons.vue'
@@ -29,10 +27,6 @@ export default {
     }
   },
   created() {
-    this.$store.dispatch('initialLoad')
-    db.settings.each(setting => {
-      console.log(setting)
-    })
     this.$store.dispatch('initialLoad')
   }
 }

--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -1,0 +1,9 @@
+{
+  "Add a new bookmark": "Neues Lesezeichen erstellen",
+  "All Bookmarks": "Alle Lesezeichen",
+  "Collections": "Sammlungen",
+  "Favorites": "Favoriten",
+  "Pinned": "Angeheftet",
+  "Search": "Suche",
+  "Tags": "Tags"
+}

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -1,0 +1,9 @@
+{
+  "Add a new bookmark": "Add a new bookmark",
+  "All Bookmarks": "All Bookmarks",
+  "Collections": "Collections",
+  "Favorites": "Favorites",
+  "Pinned": "Pinned",
+  "Search": "Search",
+  "Tags": "Tags"
+}

--- a/src/components/Collections.vue
+++ b/src/components/Collections.vue
@@ -21,7 +21,7 @@ export default {
   },
   computed: {
     collections() {
-      return this.$store.getters.getCollections
+      return this.$store.getters.collections
     }
   }
 }

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -1,7 +1,7 @@
 <template>
   <nav class="navigation" v-if="this.$route.path != '/add'">
     <div class="navigation__searchform">
-      <input type="text" class="navigation__searchformInput" placeholder="Search" />
+      <input type="text" class="navigation__searchformInput" :placeholder="strings.search" />
     </div>
     <div class="filterOptions">
       <button class="filterOptions__option">
@@ -12,12 +12,21 @@
 </template>
 
 <script>
+import __ from '../lib/translation'
+
 export default {
   name: 'Navigation',
   data() {
     return {
       title: this.$store.state.viewTitle || 'Navigation Title',
       groups: this.$store.state.groups
+    }
+  },
+  computed: {
+    strings() {
+      return {
+        search: __('Search', this.$store.getters.language)
+      }
     }
   }
 }

--- a/src/components/Pinned.vue
+++ b/src/components/Pinned.vue
@@ -16,7 +16,7 @@ export default {
   },
   computed: {
     pinned() {
-      return this.$store.getters.getPinned
+      return this.$store.getters.pinned
     }
   }
 }

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -45,11 +45,6 @@ export default {
   computed: {
     strings() {
       const language = this.$store.getters.language
-      console.log({
-        pinned: __('Pinned', language),
-        tags: __('Tags', language),
-        collections: __('Collections', language)
-      })
       return {
         pinned: __('Pinned', language),
         tags: __('Tags', language),

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -9,13 +9,13 @@
       </router-link>
     </div>
     <div class="sidebar__content">
-      <sidebar-group title="Pinned">
+      <sidebar-group :title="strings.pinned">
         <pinned></pinned>
       </sidebar-group>
-      <sidebar-group title="Collections">
+      <sidebar-group :title="strings.collections">
         <collections></collections>
       </sidebar-group>
-      <sidebar-group title="Tags">
+      <sidebar-group :title="strings.tags">
         <tags></tags>
       </sidebar-group>
     </div>
@@ -23,6 +23,7 @@
 </template>
 
 <script>
+import __ from '../lib/translation'
 import Pinned from './Pinned.vue'
 import Collections from './Collections.vue'
 import Tags from './Tags.vue'
@@ -39,6 +40,21 @@ export default {
   data() {
     return {
       title: this.$store.state.title
+    }
+  },
+  computed: {
+    strings() {
+      const language = this.$store.getters.language
+      console.log({
+        pinned: __('Pinned', language),
+        tags: __('Tags', language),
+        collections: __('Collections', language)
+      })
+      return {
+        pinned: __('Pinned', language),
+        tags: __('Tags', language),
+        collections: __('Collections', language)
+      }
     }
   }
 }

--- a/src/components/Tags.vue
+++ b/src/components/Tags.vue
@@ -21,7 +21,7 @@ export default {
   },
   computed: {
     collections() {
-      return this.$store.getters.getTags
+      return this.$store.getters.tags
     }
   }
 }

--- a/src/components/views/AddView.vue
+++ b/src/components/views/AddView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="add-view--content">
-    <label>Add a new bookmark</label>
+    <label>{{strings.addNewBookmark}}</label>
     <form action="">
       <input type="text" placeholder="https://markd.it" v-model="newUrl">
       <button @click.prevent="addNewBookmark">mark it</button>
@@ -9,6 +9,8 @@
 </template>
 
 <script>
+import __ from '../../lib/translation'
+
 export default {
   name: 'AddView',
   data() {
@@ -21,7 +23,14 @@ export default {
       console.log(this.newUrl)
     }
   },
-  computed: {}
+  computed: {
+    strings() {
+      const lang = this.$store.getters.language
+      return {
+        addNewBookmark: __('Add a new bookmark', lang)
+      }
+    }
+  }
 }
 </script>
 

--- a/src/lib/translation.js
+++ b/src/lib/translation.js
@@ -1,0 +1,13 @@
+import langEN from '../assets/lang/en.json'
+import langDE from '../assets/lang/de.json'
+
+const langs = {
+  en: langEN,
+  de: langDE
+}
+
+const __ = function(translation, lang) {
+  return langs[lang][translation] || translation
+}
+
+export default __

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,7 +1,25 @@
 import db from '../database'
 
+async function getLanguage(commit) {
+  try {
+    let lang = await db.settings
+      .where('name')
+      .equals('lang')
+      .toArray()
+
+    commit('setLanguage', lang[0].value)
+  } catch (err) {
+    console.error("Couldn't load language", err)
+  }
+}
+
 export default {
+  async loadLanguage({ commit }) {
+    getLanguage(commit)
+  },
   async initialLoad({ commit }) {
+    await getLanguage(commit)
+
     try {
       let collections = await db.collections
         .where('pinned')

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -1,18 +1,11 @@
 export default {
-  getPinned: state => {
-    return state.pinned
-  },
-  getCollections: state => {
-    return state.collections
-  },
-  getTags: state => {
-    return state.tags
-  },
-  getItems: state => {
-    return state.items
-  },
+  pinned: state => state.pinned,
+  collections: state => state.collections,
+  tags: state => state.tags,
+  items: state => state.items,
   getItemsById: state => id =>
     state.items.filter(item => item.collections.includes(Number(id))),
   getItemsByTag: state => id =>
-    state.items.filter(item => item.tags.includes(Number(id)))
+    state.items.filter(item => item.tags.includes(Number(id))),
+  language: state => state.language
 }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -10,5 +10,8 @@ export default {
   },
   setItems: (state, newItems) => {
     state.items = newItems
+  },
+  setLanguage: (state, newLanguage) => {
+    state.language = newLanguage
   }
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -13,7 +13,8 @@ export const store = new Vuex.Store({
     pinned: [],
     collections: [],
     tags: [],
-    items: []
+    items: [],
+    language: 'en'
   },
   getters: getters,
   mutations: mutations,

--- a/tests/components/Collections_test.js
+++ b/tests/components/Collections_test.js
@@ -32,7 +32,7 @@ const store = new Vuex.Store({
     ]
   },
   getters: {
-    getCollections: state => {
+    collections: state => {
       return state.collections
     }
   }

--- a/tests/components/Pinned_test.js
+++ b/tests/components/Pinned_test.js
@@ -32,7 +32,7 @@ const store = new Vuex.Store({
     ]
   },
   getters: {
-    getPinned: state => {
+    pinned: state => {
       return state.pinned
     }
   }


### PR DESCRIPTION
This adds the function `__` which allows for localization.

Example:

`__('Apples', this.$store.getters.language)` will return `Apples` in `en` and `Äpfel` in `de`.

When no key is found it will fallback to the first parameter.

Closes #47 